### PR TITLE
Removed displaying project image from modal

### DIFF
--- a/bartczak_tech/portfolio/views.py
+++ b/bartczak_tech/portfolio/views.py
@@ -24,7 +24,6 @@ def project_detail(request, project_id):
         "name": project.name,
         "short_description": project.short_description,
         "description": project.description,
-        "image_url": project.image.url if project.image else "",
         "technologies": [technology.name for technology in project.technologies.all()],
         "github_link": project.github_link,
         "project_link": project.project_link,

--- a/bartczak_tech/templates/base.html
+++ b/bartczak_tech/templates/base.html
@@ -45,53 +45,49 @@
         </script>
       {% endcomment %}
       <script>
-        document.addEventListener("DOMContentLoaded", function() {
-          const projectLinks = document.querySelectorAll(".link-custom");
-          const modal = new bootstrap.Modal(document.getElementById("projectModal"));
-          const modalProjectImage = document.getElementById("modalProjectImage");
-          const modalProjectName = document.getElementById("modalProjectName");
-          const modalProjectDescription = document.getElementById("modalProjectDescription");
-          const modalProjectTechnologies = document.getElementById("modalProjectTechnologies");
-          const modalProjectLinks = document.getElementById("modalProjectLinks"); // Add this line
+        document.addEventListener('DOMContentLoaded', function() {
+          const projectLinks = document.querySelectorAll('.project-link');
+          const modal = new bootstrap.Modal(document.getElementById('projectModal'));
+          const modalProjectName = document.getElementById('modalProjectName');
+          const modalProjectDescription = document.getElementById('modalProjectDescription');
+          const modalProjectTechnologies = document.getElementById('modalProjectTechnologies');
+          const modalProjectLinks = document.getElementById('modalProjectLinks');
 
-          projectLinks.forEach((link) => {
-            link.addEventListener("click", function(event) {
+          projectLinks.forEach(link => {
+            link.addEventListener('click', function(event) {
               event.preventDefault();
-              const {
-                projectId
-              } = this.dataset;
+              const projectId = this.dataset.projectId;
 
               fetch(`/project/${projectId}/`)
-                .then((response) => response.json())
-                .then((data) => {
-                  modalProjectImage.src = data.image_url;
+                .then(response => response.json())
+                .then(data => {
                   modalProjectName.textContent = data.name;
                   modalProjectDescription.textContent = data.description;
 
                   // Clear previous technologies
-                  modalProjectTechnologies.innerHTML = "";
-                  data.technologies.forEach((tech) => {
-                    const li = document.createElement("li");
+                  modalProjectTechnologies.innerHTML = '';
+                  data.technologies.forEach(tech => {
+                    const li = document.createElement('li');
                     li.textContent = tech;
                     modalProjectTechnologies.appendChild(li);
                   });
 
                   // Add project links
-                  modalProjectLinks.innerHTML = "";
+                  modalProjectLinks.innerHTML = '';
                   if (data.github_link) {
-                    const githubLink = document.createElement("a");
+                    const githubLink = document.createElement('a');
                     githubLink.href = data.github_link;
-                    githubLink.textContent = "GitHub";
-                    githubLink.target = "_blank";
+                    githubLink.textContent = 'GitHub';
+                    githubLink.target = '_blank';
                     modalProjectLinks.appendChild(githubLink);
                   }
                   if (data.project_link) {
-                    const projectLink = document.createElement("a");
+                    const projectLink = document.createElement('a');
                     projectLink.href = data.project_link;
-                    projectLink.textContent = data.project_link_text || "Project";
-                    projectLink.target = "_blank";
+                    projectLink.textContent = data.project_link_text || 'Project';
+                    projectLink.target = '_blank';
                     if (modalProjectLinks.innerHTML) {
-                      modalProjectLinks.innerHTML += " | ";
+                      modalProjectLinks.innerHTML += ' | ';
                     }
                     modalProjectLinks.appendChild(projectLink);
                   }

--- a/bartczak_tech/templates/portfolio/project_modal.html
+++ b/bartczak_tech/templates/portfolio/project_modal.html
@@ -13,23 +13,17 @@
                 aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <div class="card-custom-image rounded-4 mb-4">
-          <img id="modalProjectImage" class="rounded-4" src="" alt="Project Image" />
-        </div>
         <h4 id="modalProjectName"></h4>
         <p>
           <strong>Description:</strong>
         </p>
-        <!-- Add this line -->
         <p id="modalProjectDescription"></p>
         <p>
           <strong>Technologies:</strong>
         </p>
-        <!-- Add this line -->
         <ul id="modalProjectTechnologies">
         </ul>
         <p id="modalProjectLinks"></p>
-        <!-- Add this line -->
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-brand" data-bs-dismiss="modal">Close</button>


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Remove the display of project images from the project modal, simplifying the modal content and focusing on project details such as name, description, technologies, and links.

Enhancements:
- Remove the project image display from the project modal in the user interface.

<!-- Generated by sourcery-ai[bot]: end summary -->